### PR TITLE
fix missing tidyverse and rm deployment

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -2,17 +2,18 @@ library(targets)
 library(tarchetypes)
 source("R/functions.R")
 options(tidyverse.quiet = TRUE)
+
+tar_option_set(packages = c("tidyverse"))
+
 list(
   tar_target(
     raw_data_file,
     "data/raw_data.csv",
-    format = "file",
-    deployment = "main"
+    format = "file"
   ),
   tar_target(
     raw_data,
-    read_csv(raw_data_file, col_types = cols()),
-    deployment = "main"
+    read_csv(raw_data_file, col_types = cols())
   ),
   tar_target(
     data,
@@ -20,5 +21,5 @@ list(
       mutate(Ozone = replace_na(Ozone, mean(Ozone, na.rm = TRUE)))
   ),
   tar_target(hist, create_plot(data)),
-  tar_target(fit, biglm(Ozone ~ Wind + Temp, data))
+  tar_target(fit, lm(Ozone ~ Wind + Temp, data))
 )


### PR DESCRIPTION
# Prework

* [X] I understand and agree to this repository's [code of conduct](https://github.com/wlandau/targets-minimal/blob/main/CODE_OF_CONDUCT.md).
* [X] I understand and agree to this repository's [contributing guidelines](https://github.com/wlandau/targets-minimal/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an issue to the [issue tracker](http://github.com/wlandau/targets-minimal/issues) to discuss my idea with the maintainer.

# Summary

Hey @wlandau, just a couple minor changes to the `_targets.R` script. I understand you are currently updating the targets-minimal example and the targets package is under review at rOpenSci - so my apologies if this isn't the best time. 

Just cloned the targets-minimal example to build a MWE for a problem I had a little while back, and it didn't run through because of the missing `tar_options_set` line. And (IMO) I think for a beginner user, the deployment arguments are not necessary. 

Thanks!


# Checklist

* [X] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
